### PR TITLE
A refactoring attempt for the Retina display issue (#94)

### DIFF
--- a/src/laybasic/laybasic/layLayoutCanvas.h
+++ b/src/laybasic/laybasic/layLayoutCanvas.h
@@ -367,6 +367,8 @@ private:
   lay::DitherPattern m_dither_pattern;
   lay::LineStyles m_line_styles;
   unsigned int m_oversampling;
+  unsigned int m_dpr;
+  double m_gamma;
 
   bool m_need_redraw;
   bool m_redraw_clearing;

--- a/src/laybasic/laybasic/layRubberBox.cc
+++ b/src/laybasic/laybasic/layRubberBox.cc
@@ -59,7 +59,8 @@ void
 RubberBox::render (const Viewport &vp, ViewObjectCanvas &canvas)
 { 
   lay::Renderer &r = canvas.renderer ();
-  lay::CanvasPlane *plane = canvas.plane (lay::ViewOp (m_color, lay::ViewOp::Copy, 0, m_stipple, 0));
+  int lw = int (0.5 + 1.0 / r.resolution ());
+  lay::CanvasPlane *plane = canvas.plane (lay::ViewOp (m_color, lay::ViewOp::Copy, 0, m_stipple, 0, lay::ViewOp::Rect, lw));
   if (plane) {
     r.draw (vp.trans () * db::DBox (m_p1, m_p2), 0, plane, 0, 0);
   }


### PR DESCRIPTION
This is what's been done:
 - remove the old double and single buffering /w mask approach
 - modify the bitmap rendering so it's done in a offscreen
   image before subsampling
   (effect: rulers display smoothly in subsampling mode)
 - refactoring the "device pixel ratio" topic:
   Made the DPR a variable, viewport width is scaled up
   to reflect the true image size, inserted #ifdef's for Qt4.

DISCLAIMER: I don't know whether this still works - I don't
have a Retina display :-(