### PR TITLE
(Partial) attempt to fix the plugin detection issue on MacOS

### DIFF
--- a/macbuild/build4mac.py
+++ b/macbuild/build4mac.py
@@ -637,6 +637,7 @@ def DeployBinariesForBundle():
   os.chdir( targetDirF )
   dynamicLinkLibs = glob.glob( os.path.join( AbsMacBinDir, "*.dylib" ) )
   depDicOrdinary  = {} # inter-library dependency dictionary
+  pathDic = {} # paths to insert for each library
   for item in dynamicLinkLibs:
     if os.path.isfile(item) and not os.path.islink(item):
       #-------------------------------------------------------------------
@@ -650,13 +651,54 @@ def DeployBinariesForBundle():
       os.chmod( nameStyle3, 0o0755 )
       #-------------------------------------------------------------------
       # (B) Then get inter-library dependencies
+      #     Note that will pull all dependencies and sort them out later
+      #     dropping those which don't have a path entry
       #-------------------------------------------------------------------
-      otoolCm   = "otool -L %s | grep libklayout" % nameStyle3
+      otoolCm   = "otool -L %s | grep dylib" % nameStyle3
       otoolOut  = os.popen( otoolCm ).read()
       dependDic = DecomposeLibraryDependency(otoolOut)
       depDicOrdinary.update(dependDic)
+      #-------------------------------------------------------------------
+      # (C) This library goes into Frameworks, hence record it's path there
+      #-------------------------------------------------------------------
+      pathDic[nameStyle3] = "@executable_path/../Frameworks/" + nameStyle3 
+
+  os.chdir(ProjectDir)
+  #-------------------------------------------------------------------
+  # copy the contents of the plugin directories to a place next to the application
+  # binary
+  #-------------------------------------------------------------------
+  for piDir in [ "db_plugins", "lay_plugins" ]:
+    os.makedirs( os.path.join( targetDirM, piDir ), exist_ok = True )
+    dynamicLinkLibs = glob.glob( os.path.join( MacBinDir, piDir, "*.dylib" ) )
+    for item in dynamicLinkLibs:
+      if os.path.isfile(item) and not os.path.islink(item):
+        #-------------------------------------------------------------------
+        # (A) Copy an ordinary *.dylib file here by changing the name
+        #     to style (3) and set its mode to 0755 (sanity check).
+        #-------------------------------------------------------------------
+        fullName = os.path.basename(item).split('.')
+        # e.g. [ 'libklayout_lay', '0', '25', '0', 'dylib' ]
+        nameStyle3 = fullName[0] + "." + fullName[1] + ".dylib"
+        destPath = os.path.join( targetDirM, piDir, nameStyle3 )
+        shutil.copy2( item, destPath )
+        os.chmod( destPath, 0o0755 )
+        #-------------------------------------------------------------------
+        # (B) Then get inter-library dependencies
+        #     Note that will pull all dependencies and sort them out later
+        #     dropping those which don't have a path entry
+        #-------------------------------------------------------------------
+        otoolCm   = "otool -L %s | grep 'dylib'" % destPath
+        otoolOut  = os.popen( otoolCm ).read()
+        dependDic = DecomposeLibraryDependency(otoolOut)
+        depDicOrdinary.update(dependDic)
+        #-------------------------------------------------------------------
+        # (C) This library goes into the plugin dir
+        #-------------------------------------------------------------------
+        pathDic[nameStyle3] = "@executable_path/" + piDir + "/" + nameStyle3 
+  
   '''
-  PrintLibraryDependencyDictionary( depDicOrdinary, "Style (3)" )
+  PrintLibraryDependencyDictionary( depDicOrdinary, pathDic, "Style (3)" )
   exit()
   '''
 
@@ -666,7 +708,8 @@ def DeployBinariesForBundle():
   #     and make the library aware of the locations of libraries
   #     on which it depends; that is, inter-library dependency
   #-------------------------------------------------------------
-  ret = SetChangeIdentificationNameOfDyLib( depDicOrdinary )
+  os.chdir( targetDirF )
+  ret = SetChangeIdentificationNameOfDyLib( depDicOrdinary, pathDic )
   if not ret == 0:
     msg = "!!! Failed to set and change to new identification names !!!"
     print(msg)
@@ -694,23 +737,6 @@ def DeployBinariesForBundle():
   shutil.copy2( sourceDir0 + "/PkgInfo",      targetDir0 ) # this file is not mandatory
   shutil.copy2( sourceDir1 + "/klayout",      targetDirM )
   shutil.copy2( sourceDir2 + "/klayout.icns", targetDirR )
-
-  # copy the contents of the plugin directories to a place next to the application
-  # binary
-  for piDir in [ "db_plugins", "lay_plugins" ]:
-    os.makedirs( os.path.join( targetDirM, piDir ), exist_ok = True )
-    dynamicLinkLibs = glob.glob( os.path.join( sourceDir3, piDir, "*.dylib" ) )
-    for item in dynamicLinkLibs:
-      if os.path.isfile(item) and not os.path.islink(item):
-        #-------------------------------------------------------------------
-        # (A) Copy an ordinary *.dylib file here by changing the name
-        #     to style (3) and set its mode to 0755 (sanity check).
-        #-------------------------------------------------------------------
-        fullName = os.path.basename(item).split('.')
-        # e.g. [ 'libklayout_lay', '0', '25', '0', 'dylib' ]
-        nameStyle3 = os.path.join( targetDirM, piDir, fullName[0] + "." + fullName[1] + ".dylib" )
-        shutil.copy2( item, nameStyle3 )
-        os.chmod( nameStyle3, 0o0755 )
 
   os.chmod( targetDir0 + "/PkgInfo",      0o0644 )
   os.chmod( targetDir0 + "/Info.plist",   0o0644 )

--- a/macbuild/build4mac.py
+++ b/macbuild/build4mac.py
@@ -581,6 +581,10 @@ def DeployBinariesForBundle():
   #                             |              +-- '*.dylib'
   #                             +-- MacOS/+
   #                             |         +-- 'klayout'
+  #                             |         +-- 'db_plugins'/+
+  #                             |                          +-- '*.dylib'
+  #                             |         +-- 'lay_plugins'/+
+  #                             |                           +-- '*.dylib'
   #                             +-- Buddy/+
   #                                       +-- 'strm2cif'
   #                                       +-- 'strm2dxf'
@@ -631,7 +635,7 @@ def DeployBinariesForBundle():
   #       :
   #-------------------------------------------------------------------------------
   os.chdir( targetDirF )
-  dynamicLinkLibs = glob.glob( AbsMacBinDir + "/*.dylib" )
+  dynamicLinkLibs = glob.glob( os.path.join( AbsMacBinDir, "*.dylib" ) )
   depDicOrdinary  = {} # inter-library dependency dictionary
   for item in dynamicLinkLibs:
     if os.path.isfile(item) and not os.path.islink(item):
@@ -691,6 +695,22 @@ def DeployBinariesForBundle():
   shutil.copy2( sourceDir1 + "/klayout",      targetDirM )
   shutil.copy2( sourceDir2 + "/klayout.icns", targetDirR )
 
+  # copy the contents of the plugin directories to a place next to the application
+  # binary
+  for piDir in [ "db_plugins", "lay_plugins" ]:
+    os.makedirs( os.path.join( targetDirM, piDir ), exist_ok = True )
+    dynamicLinkLibs = glob.glob( os.path.join( sourceDir3, piDir, "*.dylib" ) )
+    for item in dynamicLinkLibs:
+      if os.path.isfile(item) and not os.path.islink(item):
+        #-------------------------------------------------------------------
+        # (A) Copy an ordinary *.dylib file here by changing the name
+        #     to style (3) and set its mode to 0755 (sanity check).
+        #-------------------------------------------------------------------
+        fullName = os.path.basename(item).split('.')
+        # e.g. [ 'libklayout_lay', '0', '25', '0', 'dylib' ]
+        nameStyle3 = os.path.join( targetDirM, piDir, fullName[0] + "." + fullName[1] + ".dylib" )
+        shutil.copy2( item, nameStyle3 )
+        os.chmod( nameStyle3, 0o0755 )
 
   os.chmod( targetDir0 + "/PkgInfo",      0o0644 )
   os.chmod( targetDir0 + "/Info.plist",   0o0644 )

--- a/src/db/db/dbInit.cc
+++ b/src/db/db/dbInit.cc
@@ -129,6 +129,8 @@ void init (const std::vector<std::string> &_paths)
 #if defined(_WIN32)
     pattern.set_case_sensitive (false);
     pattern = std::string ("*.dll");
+#elif defined(__APPLE__)
+    pattern = std::string ("*.dylib");
 #else
     pattern = std::string ("*.so");
 #endif

--- a/src/lay/lay/layInit.cc
+++ b/src/lay/lay/layInit.cc
@@ -130,6 +130,8 @@ void init (const std::vector<std::string> &_paths)
 #if defined(_WIN32)
     pattern.set_case_sensitive (false);
     pattern = std::string ("*.dll");
+#elif defined(__APPLE__)
+    pattern = std::string ("*.dylib");
 #else
     pattern = std::string ("*.so");
 #endif

--- a/src/plugins/streamers/cif/db_plugin/dbCIFFormat.h
+++ b/src/plugins/streamers/cif/db_plugin/dbCIFFormat.h
@@ -25,6 +25,7 @@
 
 #include "dbSaveLayoutOptions.h"
 #include "dbLoadLayoutOptions.h"
+#include "dbPluginCommon.h"
 
 namespace db
 {
@@ -34,7 +35,7 @@ namespace db
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class CIFReaderOptions
+class DB_PLUGIN_PUBLIC CIFReaderOptions
   : public FormatSpecificReaderOptions
 {
 public:
@@ -118,7 +119,7 @@ public:
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class CIFWriterOptions
+class DB_PLUGIN_PUBLIC CIFWriterOptions
   : public FormatSpecificWriterOptions
 {
 public:

--- a/src/plugins/streamers/dxf/db_plugin/dbDXFFormat.h
+++ b/src/plugins/streamers/dxf/db_plugin/dbDXFFormat.h
@@ -25,6 +25,7 @@
 
 #include "dbLoadLayoutOptions.h"
 #include "dbSaveLayoutOptions.h"
+#include "dbPluginCommon.h"
 
 namespace db
 {
@@ -34,7 +35,7 @@ namespace db
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class DXFReaderOptions
+class DB_PLUGIN_PUBLIC DXFReaderOptions
   : public FormatSpecificReaderOptions
 {
 public:
@@ -192,7 +193,7 @@ public:
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class DXFWriterOptions
+class DB_PLUGIN_PUBLIC DXFWriterOptions
   : public FormatSpecificWriterOptions
 {
 public:

--- a/src/plugins/streamers/gds2/db_plugin/dbGDS2Format.h
+++ b/src/plugins/streamers/gds2/db_plugin/dbGDS2Format.h
@@ -25,6 +25,7 @@
 
 #include "dbSaveLayoutOptions.h"
 #include "dbLoadLayoutOptions.h"
+#include "dbPluginCommon.h"
 
 namespace db
 {
@@ -34,7 +35,7 @@ namespace db
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class GDS2ReaderOptions
+class DB_PLUGIN_PUBLIC GDS2ReaderOptions
   : public FormatSpecificReaderOptions
 {
 public:
@@ -97,7 +98,7 @@ public:
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class GDS2WriterOptions
+class DB_PLUGIN_PUBLIC GDS2WriterOptions
   : public FormatSpecificWriterOptions
 {
 public:

--- a/src/plugins/streamers/oasis/db_plugin/dbOASISFormat.h
+++ b/src/plugins/streamers/oasis/db_plugin/dbOASISFormat.h
@@ -25,6 +25,7 @@
 
 #include "dbSaveLayoutOptions.h"
 #include "dbLoadLayoutOptions.h"
+#include "dbPluginCommon.h"
 
 namespace db
 {
@@ -34,7 +35,7 @@ namespace db
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class OASISReaderOptions
+class DB_PLUGIN_PUBLIC OASISReaderOptions
   : public FormatSpecificReaderOptions
 {
 public:
@@ -92,7 +93,7 @@ public:
  *  NOTE: this structure is non-public linkage by intention. This way it's instantiated
  *  in all compile units and the shared object does not need to be linked.
  */
-class OASISWriterOptions
+class DB_PLUGIN_PUBLIC OASISWriterOptions
   : public FormatSpecificWriterOptions
 {
 public:


### PR DESCRIPTION
Hi Thomas,

this is a *partial* fix for the plugin detection issue on MacOS.

I have updated the plugin locators, so "*.dylib" files will be recognized. I have also updated the build script, so it copies over the plugin .dylib files. KLayout will find the plugins then.

But I don't find how to make these libraries find their proper dependencies. Maybe I have put them into the wrong folders.

The basic issue is: 
* Content/MacOS/lay_plugins/*.dylib depend on KLayout libraries from Framework and (in some cases) depend on libraries from Content/MacOS/db_plugins
* Content/MacOS/db_plugins/*.dylib depend on KLayout libraries

On Linux I have solved this issue with RPATH's, but on MacOS I don't know how to integrate such a solution in the build script. Maybe you can help. If I manually set DYLD_LIBRARY_PATH to contain the db_plugins and Framework folders, the plugins are loaded properly and I can read and write all file formats plus I see all the tools that I have moved into these plugins.

Best regards,

Matthias